### PR TITLE
Increase vmc performance

### DIFF
--- a/src/FeedForwardNeuralNetwork.cpp
+++ b/src/FeedForwardNeuralNetwork.cpp
@@ -797,6 +797,7 @@ FeedForwardNeuralNetwork::FeedForwardNeuralNetwork(FeedForwardNeuralNetwork * ff
     }
     // read and set the substrates
     _nvp = 0;
+    _flag_connected = false;
     if (ffnn->isConnected()){
         connectFFNN();
         double beta[ffnn->getNBeta()];

--- a/src/FeedForwardNeuralNetwork.cpp
+++ b/src/FeedForwardNeuralNetwork.cpp
@@ -221,6 +221,14 @@ double FeedForwardNeuralNetwork::getVariationalFirstDerivative(const int &i, con
 }
 
 
+void FeedForwardNeuralNetwork::getVariationalFirstDerivative(const int &i, double * vd1)
+{
+    for (int iv1d=0; iv1d<getNInput(); ++iv1d){
+        vd1[iv1d] = getVariationalFirstDerivative(i, iv1d);
+    }
+}
+
+
 void FeedForwardNeuralNetwork::getVariationalFirstDerivative(double ** vd1)
 {
     for (int i=0; i<getNOutput(); ++i){
@@ -237,6 +245,14 @@ double FeedForwardNeuralNetwork::getSecondDerivative(const int &i, const int &i2
 }
 
 
+void FeedForwardNeuralNetwork::getSecondDerivative(const int &i, double * d2)
+{
+    for (int i2d=0; i2d<getNInput(); ++i2d){
+        d2[i2d] = getSecondDerivative(i, i2d);
+    }
+}
+
+
 void FeedForwardNeuralNetwork::getSecondDerivative(double ** d2)
 {
     for (int i=0; i<getNOutput(); ++i){
@@ -250,6 +266,14 @@ void FeedForwardNeuralNetwork::getSecondDerivative(double ** d2)
 double FeedForwardNeuralNetwork::getFirstDerivative(const int &i, const int &i1d)
 {
     return ( _L.back()->getUnit(i+1)->getFirstDerivativeValue(i1d) );
+}
+
+
+void FeedForwardNeuralNetwork::getFirstDerivative(const int &i, double * d1)
+{
+    for (int i1d=0; i1d<getNInput(); ++i1d){
+        d1[i1d] = getFirstDerivative(i, i1d);
+    }
 }
 
 

--- a/src/FeedForwardNeuralNetwork.hpp
+++ b/src/FeedForwardNeuralNetwork.hpp
@@ -109,21 +109,24 @@ public:
     double getOutput(const int &i);
 
     void getFirstDerivative(double ** d1);
-    double getFirstDerivative(const int &i, const int &i1d); // i is the index of the output elemnet (i.e. unit=1, offset unit is meaningless), i1d the index of the input element
+    void getFirstDerivative(const int &iu, double * d1);  // iu is the unit index
+    double getFirstDerivative(const int &iu, const int &i1d); // i is the index of the output elemnet (i.e. unit=1, offset unit is meaningless), i1d the index of the input element
 
     void getSecondDerivative(double ** d2);
+    void getSecondDerivative(const int &i, double * d2);  // i is the output index
     double getSecondDerivative(const int &i, const int &i2d); // i is the index of the output element, i2d the index of the input element
 
     void getVariationalFirstDerivative(double ** vd1);
+    void getVariationalFirstDerivative(const int &i, double * vd1);  // i is the output index
     double getVariationalFirstDerivative(const int &i, const int &iv1d);  // i is the index of the output element, iv1d the index of the beta element
 
     void getCrossFirstDerivative(double *** d1vd1);
-    void getCrossFirstDerivative(const int &i, double ** d1vd1);
-    double getCrossFirstDerivative(const int &i, const int &i1d, const int &iv1d);
+    void getCrossFirstDerivative(const int &i, double ** d1vd1);  // i is the output index
+    double getCrossFirstDerivative(const int &i, const int &i1d, const int &iv1d);  // i is the index of the output element, i1d, of the input element, iv1d the index of the beta element
 
     void getCrossSecondDerivative(double *** d1vd1);
-    void getCrossSecondDerivative(const int &i, double ** d1vd1);
-    double getCrossSecondDerivative(const int &i, const int &i1d, const int &iv1d);
+    void getCrossSecondDerivative(const int &i, double ** d1vd1);  // i is the output index
+    double getCrossSecondDerivative(const int &i, const int &i2d, const int &iv1d);  // i is the index of the output element, i2d, of the input element, iv1d the index of the beta element
 
 
 


### PR DESCRIPTION
We should go for 1. and 2., but in a nicer way:
- we keep the d1, d2, and vd1 methods with the indexes, but we rename them as getD1, getD2, getVD1
- we introduce a new method called computeAllValues(double * x), which will compute and store internally in the class all the derivatives (and the WF value itself). All these values will then be accessible with the getters.



AC:
- change the code according to the new criteria
- all the unittests and example run
- update the documentation