### PR TITLE
Openmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,11 @@ In `examples/` there are several examples.
 Insert the system parameters in a file named `config.sh` (use `config_template.sh` as template) and then simply execute the command
 
    `./build.sh`
+
+
+## Multi-threading: OpenMP
+
+This library supports multi-threading computation with a shared memory paradigm, thanks to OpenMP.
+
+To activate this feature add the flags `-DOPENMP -fopenmp` to `OPTFLAGS` in the `config.sh` file.
+You also need to add the line of code `#define OPENMP` at the beginning of the file `FeedForwardNeuralNetwork.hpp` (or `.cpp`).

--- a/src/FeedForwardNeuralNetwork.cpp
+++ b/src/FeedForwardNeuralNetwork.cpp
@@ -9,7 +9,8 @@
 #include <stdexcept>
 #include <random>
 #include <limits>
-
+#include <algorithm>
+#include <thread> //to detect the number of hardware threads on the system
 
 // --- Variational Parameters
 
@@ -318,9 +319,12 @@ void FeedForwardNeuralNetwork::evaluate(const double * in, double * out, double 
     }
 }
 
+bool myfn(NNLayer * A, NNLayer * B) { return A->getNUnits()<B->getNUnits(); }
 
 void FeedForwardNeuralNetwork::FFPropagate()
 {
+    int nthreads = std::max(1, (int)std::thread::hardware_concurrency());
+#pragma omp parallel num_threads(std::min(nthreads, std::max(1, ((*std::max_element(_L.begin(), _L.end(), myfn))->getNUnits()-1)/3)))
     for (std::vector<NNLayer *>::size_type i=0; i<_L.size(); ++i)
         {
             _L[i]->computeValues();

--- a/src/FeedForwardNeuralNetwork.cpp
+++ b/src/FeedForwardNeuralNetwork.cpp
@@ -330,7 +330,8 @@ void FeedForwardNeuralNetwork::FFPropagate()
 {
 
 #ifdef OPENMP
-
+// compile with -DOPENMP -fopenmp flags to use parallelization here
+    
     int nthreads = std::min( (int)std::thread::hardware_concurrency(), (*std::max_element(_L.begin(), _L.end(), compare_NUnits))->getNUnits() - 1 );
     if (nthreads>1) {
 #pragma omp parallel num_threads(nthreads)

--- a/src/NNLayer.cpp
+++ b/src/NNLayer.cpp
@@ -64,8 +64,12 @@ int NNLayer::getNVariationalParameters()
 
 void NNLayer::computeValues()
 {
-#pragma omp parallel for schedule(dynamic, 1)
-    for (std::vector<NNUnit *>::size_type i=1; i<_U.size(); ++i) _U[i]->computeValues();
+    _U[0]->computeValues(); // offset unit
+    if (_U.size()>6 && this->getNVariationalParameters() > 0) { // only use omp for when it is useful
+#pragma omp for schedule(static, 1)
+        for (std::vector<NNUnit *>::size_type i=1; i<_U.size(); ++i) _U[i]->computeValues();
+    }
+    else for (std::vector<NNUnit *>::size_type i=1; i<_U.size(); ++i) _U[i]->computeValues();
 }
 
 

--- a/src/NNLayer.cpp
+++ b/src/NNLayer.cpp
@@ -64,7 +64,8 @@ int NNLayer::getNVariationalParameters()
 
 void NNLayer::computeValues()
 {
-    for (NNUnit * u : _U) u->computeValues();
+#pragma omp parallel for schedule(dynamic, 1)
+    for (std::vector<NNUnit *>::size_type i=1; i<_U.size(); ++i) _U[i]->computeValues();
 }
 
 

--- a/src/NNLayer.cpp
+++ b/src/NNLayer.cpp
@@ -64,12 +64,8 @@ int NNLayer::getNVariationalParameters()
 
 void NNLayer::computeValues()
 {
-    _U[0]->computeValues(); // offset unit
-    if (_U.size()>6 && this->getNVariationalParameters() > 0) { // only use omp for when it is useful
 #pragma omp for schedule(static, 1)
-        for (std::vector<NNUnit *>::size_type i=1; i<_U.size(); ++i) _U[i]->computeValues();
-    }
-    else for (std::vector<NNUnit *>::size_type i=1; i<_U.size(); ++i) _U[i]->computeValues();
+        for (std::vector<NNUnit *>::size_type i=0; i<_U.size(); ++i) _U[i]->computeValues();
 }
 
 

--- a/src/NNLayer.cpp
+++ b/src/NNLayer.cpp
@@ -64,8 +64,10 @@ int NNLayer::getNVariationalParameters()
 
 void NNLayer::computeValues()
 {
+#ifdef OPENMP
 #pragma omp for schedule(static, 1)
-        for (std::vector<NNUnit *>::size_type i=0; i<_U.size(); ++i) _U[i]->computeValues();
+#endif
+    for (std::vector<NNUnit *>::size_type i=0; i<_U.size(); ++i) _U[i]->computeValues();
 }
 
 


### PR DESCRIPTION
Added possibility to computeValues of units of a layer in parallel via OpenMP.
To use it, compile with -DOPENMP -fopenmp flags. The number of threads used is set automatically at the moment. 