### PR TITLE
Nn speed up

### DIFF
--- a/debug/unittest/run_single_unittest.sh
+++ b/debug/unittest/run_single_unittest.sh
@@ -18,7 +18,7 @@ $CC $FLAGS $DEBUGFLAGS -Wall -I${ROOT_FOLDER}/src/ -c *.cpp
 
 case ${OS_NAME} in
     "Linux")
-        $CC $FLAGS $DEBUGFLAGS -L${ROOT_FOLDER} -Wl,-rpath=$(pwd)/../../../ -o exe *.o -l${LIBNAME}
+        $CC $FLAGS $DEBUGFLAGS -L${ROOT_FOLDER} -Wl,-rpath=${ROOT_FOLDER} -o exe *.o -l${LIBNAME}
         ;;
     "Darwin")
         $CC $FLAGS $DEBUGFLAGS -L${ROOT_FOLDER} -o exe *.o -l${LIBNAME}

--- a/src/NNRay.cpp
+++ b/src/NNRay.cpp
@@ -125,31 +125,46 @@ double NNRay::getCrossSecondDerivativeFeed(const int &i2d, const int &iv2d){
 // --- Beta Index
 
 bool NNRay::isBetaIndexUsedInThisRay(const int &id){
-    std::vector<int>::iterator it_beta = std::find(_intensity_id.begin(), _intensity_id.end(), id);
-    if ( it_beta != _intensity_id.end() ){
-        return true;
+    boolean * answer = _beta_used_in_this_ray.find(id);
+    if (answer != _beta_used_in_this_ray.end()){
+        return *answer;
     } else {
-        return false;
+        std::vector<int>::iterator it_beta = std::find(_intensity_id.begin(), _intensity_id.end(), id);
+        if ( it_beta != _intensity_id.end() ){
+            _beta_used_in_this_ray[id] = true;
+            return true;
+        } else {
+            _beta_used_in_this_ray[id] = false;
+            return false;
+        }
     }
 }
 
 
 
 bool NNRay::isBetaIndexUsedForThisRay(const int &id){
-    if (isBetaIndexUsedInThisRay(id)){
-        return true;
-    }
+    boolean * answer = _beta_used_for_this_ray.find(id);
+    if (answer != _beta_used_for_this_ray.end()){
+        return *answer;
+    } else {
+        if (isBetaIndexUsedInThisRay(id)){
+            _beta_used_for_this_ray[id] = true;
+            return true;
+        }
 
-    for (NNUnit * u: _source){
-        NNUnitFeederInterface * feeder = u->getFeeder();
-        if (feeder != 0){
-            if (feeder->isBetaIndexUsedForThisRay(id)){
-                return true;
+        for (NNUnit * u: _source){
+            NNUnitFeederInterface * feeder = u->getFeeder();
+            if (feeder != 0){
+                if (feeder->isBetaIndexUsedForThisRay(id)){
+                    _beta_used_for_this_ray[id] = true;
+                    return true;
+                }
             }
         }
-    }
 
-    return false;
+        _beta_used_for_this_ray[id] = false;
+        return false;
+    }
 }
 
 

--- a/src/NNRay.cpp
+++ b/src/NNRay.cpp
@@ -38,7 +38,20 @@ int NNRay::setVariationalParametersIndexes(const int &starting_index){
     _intensity_id.clear();
     for (std::vector<double>::size_type i=0; i<_intensity.size(); ++i){
         _intensity_id.push_back(idx);
+        _betas_used_in_this_ray.push_back(idx);
+        _betas_used_for_this_ray.push_back(idx);
+
         idx++;
+    }
+    for (NNUnit * u: _source){
+        NNUnitFeederInterface * feeder = u->getFeeder();
+        if (feeder != 0){
+            for (int i=0; i<idx; ++i) {
+                if (feeder->isBetaIndexUsedForThisRay(i)){
+                    _betas_used_for_this_ray.push_back(i);
+                }
+            }
+        }
     }
     return idx;
 }
@@ -125,6 +138,13 @@ double NNRay::getCrossSecondDerivativeFeed(const int &i2d, const int &iv2d){
 // --- Beta Index
 
 bool NNRay::isBetaIndexUsedInThisRay(const int &id){
+    if (std::find(_betas_used_in_this_ray.begin(), _betas_used_in_this_ray.end(), id) != _betas_used_in_this_ray.end()) {
+        return true;
+    }
+    else {
+        return false;
+    }
+    /*
     std::map<int,bool>::iterator it = _beta_used_in_this_ray.find(id);
     if (it != _beta_used_in_this_ray.end()){
         return it->second;
@@ -137,12 +157,19 @@ bool NNRay::isBetaIndexUsedInThisRay(const int &id){
             _beta_used_in_this_ray[id] = false;
             return false;
         }
-    }
+        }*/
 }
 
 
 
 bool NNRay::isBetaIndexUsedForThisRay(const int &id){
+    if (std::find(_betas_used_for_this_ray.begin(), _betas_used_for_this_ray.end(), id) != _betas_used_for_this_ray.end()) {
+        return true;
+    }
+    else {
+        return false;
+    }
+    /*
     std::map<int,bool>::iterator it = _beta_used_for_this_ray.find(id);
     if (it != _beta_used_for_this_ray.end()){
         return it->second;
@@ -164,7 +191,7 @@ bool NNRay::isBetaIndexUsedForThisRay(const int &id){
 
         _beta_used_for_this_ray[id] = false;
         return false;
-    }
+    }*/
 }
 
 
@@ -194,6 +221,6 @@ NNRay::~NNRay(){
     _source.clear();
     _intensity.clear();
     _intensity_id.clear();
-    _beta_used_in_this_ray.clear();
-    _beta_used_for_this_ray.clear();
+    _betas_used_in_this_ray.clear();
+    _betas_used_for_this_ray.clear();
 }

--- a/src/NNRay.cpp
+++ b/src/NNRay.cpp
@@ -125,9 +125,9 @@ double NNRay::getCrossSecondDerivativeFeed(const int &i2d, const int &iv2d){
 // --- Beta Index
 
 bool NNRay::isBetaIndexUsedInThisRay(const int &id){
-    boolean * answer = _beta_used_in_this_ray.find(id);
-    if (answer != _beta_used_in_this_ray.end()){
-        return *answer;
+    std::map<int,bool>::iterator it = _beta_used_for_this_ray.find(id);
+    if (it != _beta_used_in_this_ray.end()){
+        return it->second;
     } else {
         std::vector<int>::iterator it_beta = std::find(_intensity_id.begin(), _intensity_id.end(), id);
         if ( it_beta != _intensity_id.end() ){
@@ -143,9 +143,9 @@ bool NNRay::isBetaIndexUsedInThisRay(const int &id){
 
 
 bool NNRay::isBetaIndexUsedForThisRay(const int &id){
-    boolean * answer = _beta_used_for_this_ray.find(id);
-    if (answer != _beta_used_for_this_ray.end()){
-        return *answer;
+    std::map<int,bool>::iterator it = _beta_used_for_this_ray.find(id);
+    if (it != _beta_used_for_this_ray.end()){
+        return it->second;
     } else {
         if (isBetaIndexUsedInThisRay(id)){
             _beta_used_for_this_ray[id] = true;
@@ -194,4 +194,6 @@ NNRay::~NNRay(){
     _source.clear();
     _intensity.clear();
     _intensity_id.clear();
+    _beta_used_in_this_ray.clear();
+    _beta_used_for_this_ray.clear();
 }

--- a/src/NNRay.cpp
+++ b/src/NNRay.cpp
@@ -34,25 +34,30 @@ bool NNRay::getVariationalParameterValue(const int &id, double &value){
 int NNRay::setVariationalParametersIndexes(const int &starting_index){
     _intensity_id_shift=starting_index;
 
-    int idx=starting_index;
-    _intensity_id.clear();
-    for (std::vector<double>::size_type i=0; i<_intensity.size(); ++i){
-        _intensity_id.push_back(idx);
-        _betas_used_in_this_ray.push_back(idx);
-        _betas_used_for_this_ray.push_back(idx);
-
-        idx++;
-    }
     for (NNUnit * u: _source){
         NNUnitFeederInterface * feeder = u->getFeeder();
         if (feeder != 0){
-            for (int i=0; i<idx; ++i) {
+            for (int i=0; i<starting_index; ++i) {
                 if (feeder->isBetaIndexUsedForThisRay(i)){
-                    _betas_used_for_this_ray.push_back(i);
+                    _betas_used_for_this_ray.insert(i);
                 }
             }
         }
     }
+
+    int idx=starting_index;
+    _intensity_id.clear();
+    for (std::vector<double>::size_type i=0; i<_intensity.size(); ++i){
+        _intensity_id.push_back(idx);
+        _betas_used_in_this_ray.insert(idx);
+        _betas_used_for_this_ray.insert(idx);
+
+        idx++;
+    }
+    //both betas_used vectors are sorted -> binary_search can be used later
+    //std::cout << is_sorted(_betas_used_in_this_ray.begin(), _betas_used_in_this_ray.end()) << std::endl;
+    //std::cout << is_sorted(_betas_used_for_this_ray.begin(), _betas_used_for_this_ray.end()) << std::endl;
+
     return idx;
 }
 
@@ -138,7 +143,9 @@ double NNRay::getCrossSecondDerivativeFeed(const int &i2d, const int &iv2d){
 // --- Beta Index
 
 bool NNRay::isBetaIndexUsedInThisRay(const int &id){
-    if (std::find(_betas_used_in_this_ray.begin(), _betas_used_in_this_ray.end(), id) != _betas_used_in_this_ray.end()) {
+    //if (std::binary_search(_betas_used_in_this_ray.begin(), _betas_used_in_this_ray.end(), id)) {
+    //if (std::find(_betas_used_in_this_ray.begin(), _betas_used_in_this_ray.end(), id) != _betas_used_in_this_ray.end()) {
+    if ( _betas_used_in_this_ray.find(id) != _betas_used_in_this_ray.end()) {
         return true;
     }
     else {
@@ -163,7 +170,9 @@ bool NNRay::isBetaIndexUsedInThisRay(const int &id){
 
 
 bool NNRay::isBetaIndexUsedForThisRay(const int &id){
-    if (std::find(_betas_used_for_this_ray.begin(), _betas_used_for_this_ray.end(), id) != _betas_used_for_this_ray.end()) {
+    //if (std::binary_search(_betas_used_for_this_ray.begin(), _betas_used_for_this_ray.end(), id)) {
+    //if (std::find(_betas_used_for_this_ray.begin(), _betas_used_for_this_ray.end(), id) != _betas_used_for_this_ray.end()) {
+    if ( _betas_used_for_this_ray.find(id) != _betas_used_for_this_ray.end()) {
         return true;
     }
     else {

--- a/src/NNRay.cpp
+++ b/src/NNRay.cpp
@@ -125,7 +125,7 @@ double NNRay::getCrossSecondDerivativeFeed(const int &i2d, const int &iv2d){
 // --- Beta Index
 
 bool NNRay::isBetaIndexUsedInThisRay(const int &id){
-    std::map<int,bool>::iterator it = _beta_used_for_this_ray.find(id);
+    std::map<int,bool>::iterator it = _beta_used_in_this_ray.find(id);
     if (it != _beta_used_in_this_ray.end()){
         return it->second;
     } else {

--- a/src/NNRay.cpp
+++ b/src/NNRay.cpp
@@ -1,9 +1,6 @@
 #include "NNRay.hpp"
 
-#include <iostream>
 #include <algorithm>
-
-
 
 
 // --- Variational Parameters
@@ -32,8 +29,13 @@ bool NNRay::getVariationalParameterValue(const int &id, double &value){
 
 
 int NNRay::setVariationalParametersIndexes(const int &starting_index){
-    _intensity_id_shift=starting_index;
-
+    // Here we assign external vp indexes to internal indexes.
+    // Also, we create two betas_used sets which are explained in the header.
+    // NOTE: The current method assumes, that no index larger than max_id,
+    //       max_id = starting_index + source.size() - 1 ,
+    //       may be in use FOR (and trivially IN) this ray. 
+    // NOTE2: betas_used sets are automatically sorted -> binary_search can be used later
+    
     for (NNUnit * u: _source){
         NNUnitFeederInterface * feeder = u->getFeeder();
         if (feeder != 0){
@@ -45,6 +47,7 @@ int NNRay::setVariationalParametersIndexes(const int &starting_index){
         }
     }
 
+    _intensity_id_shift=starting_index;
     int idx=starting_index;
     _intensity_id.clear();
     for (std::vector<double>::size_type i=0; i<_intensity.size(); ++i){
@@ -54,9 +57,6 @@ int NNRay::setVariationalParametersIndexes(const int &starting_index){
 
         idx++;
     }
-    //both betas_used vectors are sorted -> binary_search can be used later
-    //std::cout << is_sorted(_betas_used_in_this_ray.begin(), _betas_used_in_this_ray.end()) << std::endl;
-    //std::cout << is_sorted(_betas_used_for_this_ray.begin(), _betas_used_for_this_ray.end()) << std::endl;
 
     return idx;
 }
@@ -139,70 +139,26 @@ double NNRay::getCrossSecondDerivativeFeed(const int &i2d, const int &iv2d){
 }
 
 
-
 // --- Beta Index
 
 bool NNRay::isBetaIndexUsedInThisRay(const int &id){
-    //if (std::binary_search(_betas_used_in_this_ray.begin(), _betas_used_in_this_ray.end(), id)) {
-    //if (std::find(_betas_used_in_this_ray.begin(), _betas_used_in_this_ray.end(), id) != _betas_used_in_this_ray.end()) {
     if ( _betas_used_in_this_ray.find(id) != _betas_used_in_this_ray.end()) {
         return true;
     }
     else {
         return false;
     }
-    /*
-    std::map<int,bool>::iterator it = _beta_used_in_this_ray.find(id);
-    if (it != _beta_used_in_this_ray.end()){
-        return it->second;
-    } else {
-        std::vector<int>::iterator it_beta = std::find(_intensity_id.begin(), _intensity_id.end(), id);
-        if ( it_beta != _intensity_id.end() ){
-            _beta_used_in_this_ray[id] = true;
-            return true;
-        } else {
-            _beta_used_in_this_ray[id] = false;
-            return false;
-        }
-        }*/
 }
 
 
-
 bool NNRay::isBetaIndexUsedForThisRay(const int &id){
-    //if (std::binary_search(_betas_used_for_this_ray.begin(), _betas_used_for_this_ray.end(), id)) {
-    //if (std::find(_betas_used_for_this_ray.begin(), _betas_used_for_this_ray.end(), id) != _betas_used_for_this_ray.end()) {
     if ( _betas_used_for_this_ray.find(id) != _betas_used_for_this_ray.end()) {
         return true;
     }
     else {
         return false;
     }
-    /*
-    std::map<int,bool>::iterator it = _beta_used_for_this_ray.find(id);
-    if (it != _beta_used_for_this_ray.end()){
-        return it->second;
-    } else {
-        if (isBetaIndexUsedInThisRay(id)){
-            _beta_used_for_this_ray[id] = true;
-            return true;
-        }
-
-        for (NNUnit * u: _source){
-            NNUnitFeederInterface * feeder = u->getFeeder();
-            if (feeder != 0){
-                if (feeder->isBetaIndexUsedForThisRay(id)){
-                    _beta_used_for_this_ray[id] = true;
-                    return true;
-                }
-            }
-        }
-
-        _beta_used_for_this_ray[id] = false;
-        return false;
-    }*/
 }
-
 
 
 // --- Constructor

--- a/src/NNRay.hpp
+++ b/src/NNRay.hpp
@@ -27,12 +27,12 @@ protected:
     //     'for' this ray means that the beta is either used in this ray or in another
     //           ray that genreates an output that is directly or indirectly used
     //           in this ray (sources)
-    std::map<int, boolean> _beta_used_in_this_ray;
-    std::map<int, boolean> _beta_used_for_this_ray;
+    std::map<int, bool> _beta_used_in_this_ray;
+    std::map<int, bool> _beta_used_for_this_ray;
 
 public:
     NNRay(NNLayer * nnl);
-    virtual ~NNRay(){_beta_used_in_this_ray.clear(); _beta_used_for_this_ray.clear()};
+    virtual ~NNRay();
 
     // beta
     int getNBeta(){return _intensity.size();}

--- a/src/NNRay.hpp
+++ b/src/NNRay.hpp
@@ -7,6 +7,7 @@
 
 #include <vector>
 #include <random>
+#include <map>
 
 class NNRay: public NNUnitFeederInterface{
 protected:
@@ -21,9 +22,17 @@ protected:
     std::vector<int> _intensity_id;  // intensity identification id, useful for the NN
     int _intensity_id_shift;  // shift of the previous vector
 
+    // store information about which beta are used in or for this ray
+    // NB: 'in' this ray means that the beta is part of the ray
+    //     'for' this ray means that the beta is either used in this ray or in another
+    //           ray that genreates an output that is directly or indirectly used
+    //           in this ray (sources)
+    std::map<int, boolean> _beta_used_in_this_ray;
+    std::map<int, boolean> _beta_used_for_this_ray;
+
 public:
     NNRay(NNLayer * nnl);
-    virtual ~NNRay();
+    virtual ~NNRay(){_beta_used_in_this_ray.clear(); _beta_used_for_this_ray.clear()};
 
     // beta
     int getNBeta(){return _intensity.size();}

--- a/src/NNRay.hpp
+++ b/src/NNRay.hpp
@@ -27,8 +27,8 @@ protected:
     //     'for' this ray means that the beta is either used in this ray or in another
     //           ray that genreates an output that is directly or indirectly used
     //           in this ray (sources)
-    std::map<int, bool> _beta_used_in_this_ray;
-    std::map<int, bool> _beta_used_for_this_ray;
+    std::vector<int> _betas_used_in_this_ray;
+    std::vector<int> _betas_used_for_this_ray;
 
 public:
     NNRay(NNLayer * nnl);

--- a/src/NNRay.hpp
+++ b/src/NNRay.hpp
@@ -6,8 +6,9 @@
 #include "NNUnitFeederInterface.hpp"
 
 #include <vector>
+#include <set>
 #include <random>
-#include <map>
+//#include <map>
 
 class NNRay: public NNUnitFeederInterface{
 protected:
@@ -27,8 +28,10 @@ protected:
     //     'for' this ray means that the beta is either used in this ray or in another
     //           ray that genreates an output that is directly or indirectly used
     //           in this ray (sources)
-    std::vector<int> _betas_used_in_this_ray;
-    std::vector<int> _betas_used_for_this_ray;
+    //std::map<int,bool> _beta_used_in_this_ray;
+    //std::map<int,bool> _beta_used_for_this_ray;
+    std::set<int> _betas_used_in_this_ray;
+    std::set<int> _betas_used_for_this_ray;
 
 public:
     NNRay(NNLayer * nnl);

--- a/src/NNRay.hpp
+++ b/src/NNRay.hpp
@@ -8,7 +8,6 @@
 #include <vector>
 #include <set>
 #include <random>
-//#include <map>
 
 class NNRay: public NNUnitFeederInterface{
 protected:
@@ -28,8 +27,6 @@ protected:
     //     'for' this ray means that the beta is either used in this ray or in another
     //           ray that genreates an output that is directly or indirectly used
     //           in this ray (sources)
-    //std::map<int,bool> _beta_used_in_this_ray;
-    //std::map<int,bool> _beta_used_for_this_ray;
     std::set<int> _betas_used_in_this_ray;
     std::set<int> _betas_used_for_this_ray;
 


### PR DESCRIPTION
The current implementation of isBetaUsedInThisRay and isBetaUsedForThisRay methods of NNRay appeared at the top spot in performance profiles. Hence, a more efficient implementation was desired.

To achieve more efficient computation, we calculate ordered sets of beta indexes used in and for this ray and do so at "connect" time, i.e. when setVariationParametersIndexes is called. This allows the isBetaUsed... questions at "compute" time in a fast manner, by using binary search on these ordered sets.

NOTE: 
The current method assumes that no index larger than max_id,
    max_id = starting_index + source.size() - 1 ,
 may be in use FOR (and trivially IN) this ray. 